### PR TITLE
Fix login session and add role-based access control

### DIFF
--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,0 +1,34 @@
+<?php
+// Authentication helper functions
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+/**
+ * Ensure the user is logged in. Redirects to login.php if not.
+ */
+function require_login(): void
+{
+    if (empty($_SESSION['user_id'])) {
+        header('Location: login.php');
+        exit;
+    }
+}
+
+/**
+ * Ensure the current user has one of the allowed roles.
+ *
+ * @param string|array $roles Allowed role or roles
+ */
+function require_role($roles): void
+{
+    require_login();
+    $role = $_SESSION['role'] ?? '';
+    if (!in_array($role, (array) $roles, true)) {
+        header('Location: index.php');
+        exit;
+    }
+}
+
+?>
+

--- a/includes/common-header.php
+++ b/includes/common-header.php
@@ -7,6 +7,7 @@ if (session_status() === PHP_SESSION_NONE) {
 
 // Optional: include auth helpers
 require_once __DIR__ . '/auth.php';
+require_login();
 
 // You can add global meta, CSS links here if desired
 ?>

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -43,7 +43,9 @@
     <ul>
         <li><a href="index.php"><img src="assets/icons/home.png" class="icon" alt=""><span>Dashboard</span></a></li>
         <li><a href="reports-library.php"><img src="assets/icons/report.png" class="icon" alt=""><span>Reports Library</span></a></li>
+        <?php if (($_SESSION['role'] ?? '') === 'Admin'): ?>
         <li><a href="users.php"><img src="assets/icons/user.png" class="icon" alt=""><span>Users</span></a></li>
+        <?php endif; ?>
     </ul>
 
 </div>

--- a/includes/topbar.php
+++ b/includes/topbar.php
@@ -1,17 +1,6 @@
 <?php
-session_start();
-
-// agar user login nahi hai to login page par bhejo
-if (!isset($_SESSION['username'])) {
-    header("Location: login.php");
-    exit();
-}
-
-// agar logout par click kare to session destroy
-if (isset($_GET['logout'])) {
-    session_destroy();
-    header("Location: login.php");
-    exit();
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
 }
 ?>
 
@@ -25,11 +14,11 @@ if (isset($_GET['logout'])) {
         <div class="user-menu" id="userMenu">
             <img src="assets/icons/profile.png" alt="User">
             <!-- yahan session ka username show hoga -->
-            <h6><?php echo htmlspecialchars($_SESSION['username']); ?></h6>
+            <h6><?php echo htmlspecialchars($_SESSION['username'] ?? ''); ?></h6>
             <ul class="dropdown-menu" id="dropdownMenu">
                 <li><a href="profile.php">Profile</a></li>
                 <li><a href="settings.php">Settings</a></li>
-                <li><a href="?logout=true">Logout</a></li>
+                <li><a href="logout.php">Logout</a></li>
             </ul>
         </div>
     </div>

--- a/login.php
+++ b/login.php
@@ -13,6 +13,7 @@ if (isset($_POST['login'])) {
     if ($user && password_verify($password, $user['password'])) {
         $_SESSION['user_id'] = $user['id'];
         $_SESSION['role'] = $user['role'];
+        $_SESSION['username'] = $user['username'];
         $_SESSION['name'] = $user['name'];
         header("Location: index.php");
         exit;

--- a/users.php
+++ b/users.php
@@ -1,6 +1,8 @@
 <?php
-include 'includes/common-header.php';
+require __DIR__ . '/includes/auth.php';
+require_role('Admin');
 require __DIR__ . '/includes/db.php';
+include 'includes/common-header.php';
 
 
 $successMessage = "";


### PR DESCRIPTION
## Summary
- set username in session on login so successful authentication redirects to dashboard
- add reusable auth helpers with role checks and enforce login globally
- hide Users menu and block access unless the user has Admin role

## Testing
- `php -l login.php includes/auth.php includes/common-header.php includes/topbar.php includes/sidebar.php users.php`


------
https://chatgpt.com/codex/tasks/task_e_68afeb85971083248b61c306a8831a63